### PR TITLE
Upgrade for latest Rust

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "liquidfun"
-version = "0.8.0"
+version = "0.8.1"
 authors = ["Richard Janicek <r@janicek.co>"]
 description = "Rust bindings for LiquidFun."
 license = "MIT"

--- a/src/box2d/collision/shapes/polygon_shape.rs
+++ b/src/box2d/collision/shapes/polygon_shape.rs
@@ -6,7 +6,7 @@ enum B2PolygonShape {}
 
 extern {
     fn b2PolygonShape_Delete(ptr: *mut B2PolygonShape);
-    fn b2PolygonShape_GetVertex(ptr: *mut B2PolygonShape, index: Int32) -> &Vec2;
+    fn b2PolygonShape_GetVertex(ptr: &B2PolygonShape, index: Int32) -> &Vec2;
     fn b2PolygonShape_GetVertexCount(ptr: *const B2PolygonShape) -> Int32;
     fn b2PolygonShape_New() -> *mut B2PolygonShape;
     fn b2PolygonShape_SetAsBox(ptr: *mut B2PolygonShape, hx: Float32, hy: Float32);
@@ -49,7 +49,7 @@ impl PolygonShape {
     /// Get a vertex by index.
     pub fn get_vertex(&self, index: i32) -> &Vec2 {
         unsafe {
-            b2PolygonShape_GetVertex(self.ptr, index)
+            b2PolygonShape_GetVertex(&*self.ptr, index)
         }
     }
 

--- a/src/box2d/dynamics/body.rs
+++ b/src/box2d/dynamics/body.rs
@@ -114,7 +114,6 @@ extern {
 }
 
 /// A rigid body. These are created via b2World::CreateBody.
-#[allow(raw_pointer_derive)]
 #[derive(Clone, Debug)]
 pub struct Body {
 	pub ptr: *mut B2Body

--- a/src/box2d/dynamics/body.rs
+++ b/src/box2d/dynamics/body.rs
@@ -107,7 +107,7 @@ extern {
     fn b2Body_GetAngle(this: *mut B2Body) -> Float32;
     fn b2Body_GetFixtureList(this: *mut B2Body) -> *mut B2Fixture;
     fn b2Body_GetNext(this: *mut B2Body) -> *mut B2Body;
-    fn b2Body_GetPosition(this: *mut B2Body) -> &Vec2;
+    fn b2Body_GetPosition(this: &B2Body) -> &Vec2;
     fn b2Body_GetUserData(this: *const B2Body) -> usize;
     fn b2Body_GetWorld(this: *const B2Body) -> *mut B2World;
     fn b2Body_GetLocalPoint(this: *const B2Body, worldPoint: &Vec2) -> Vec2;
@@ -189,7 +189,7 @@ impl Body {
     /// @return the world position of the body's origin.
     pub fn get_position(&self) -> &Vec2 {
         unsafe {
-            b2Body_GetPosition(self.ptr)
+            b2Body_GetPosition(&*self.ptr)
         }
     }
 

--- a/src/box2d/dynamics/fixture.rs
+++ b/src/box2d/dynamics/fixture.rs
@@ -84,7 +84,6 @@ extern {
 /// such as friction, collision filters, etc.
 /// Fixtures are created via b2Body::CreateFixture.
 /// @warning you cannot reuse fixtures.
-#[allow(raw_pointer_derive)]
 #[derive(Clone)]
 pub struct Fixture {
     pub ptr: *mut B2Fixture

--- a/src/box2d/dynamics/joints/revolute_joint.rs
+++ b/src/box2d/dynamics/joints/revolute_joint.rs
@@ -91,7 +91,6 @@ extern {
 /// a joint limit that specifies a lower and upper angle. You can use a motor
 /// to drive the relative rotation about the shared point. A maximum motor torque
 /// is provided so that infinite forces are not generated.
-#[allow(raw_pointer_derive)]
 #[derive(Clone, Debug)]
 pub struct RevoluteJoint {
 	pub ptr: *mut B2RevoluteJoint

--- a/src/box2d/particle/particle_color.rs
+++ b/src/box2d/particle/particle_color.rs
@@ -11,7 +11,6 @@ extern {
 
 
 /// Small color object for each particle
-#[allow(raw_pointer_derive)]
 #[derive(Clone)]
 pub struct ParticleColor {
 	pub ptr: *mut B2ParticleColor

--- a/src/box2d/particle/particle_group.rs
+++ b/src/box2d/particle/particle_group.rs
@@ -1,7 +1,6 @@
 pub enum B2ParticleGroup {}
 
 /// A group of particles. b2ParticleGroup::CreateParticleGroup creates these.
-#[allow(raw_pointer_derive)]
 #[derive(Clone)]
 pub struct ParticleGroup {
     pub ptr: *mut B2ParticleGroup

--- a/src/box2d/particle/particle_system.rs
+++ b/src/box2d/particle/particle_system.rs
@@ -142,7 +142,6 @@ extern {
     fn b2ParticleSystem_GetPositionBuffer(ps: *mut B2ParticleSystem) -> *mut Vec2;
 }
 
-#[allow(raw_pointer_derive)]
 #[derive(Clone)]
 pub struct ParticleSystem {
     pub ptr: *mut B2ParticleSystem


### PR DESCRIPTION
This crate hits the ICE described in https://github.com/rust-lang/rust/issues/43567 , which may be turned into a proper error.

In general returning a type with a lifetime from FFI in a function that has no arguments with lifetimes used to be allowed, but it is a bug, since that lifetime will be effectively `'static`. Normal functions do not allow this.

Fixing this so that this works in the future.

Please publish after merging.